### PR TITLE
Adding POWhash to RPC 'getblock' call.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -47,6 +47,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
 {
     Object result;
     result.push_back(Pair("hash", block.GetHash().GetHex()));
+    result.push_back(Pair("powhash", block.GetPOWHash().GetHex()));
     CMerkleTx txGen(block.vtx[0]);
     txGen.SetMerkleBranch(&block);
     result.push_back(Pair("confirmations", (int)txGen.GetDepthInMainChain()));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -47,7 +47,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
 {
     Object result;
     result.push_back(Pair("hash", block.GetHash().GetHex()));
-    result.push_back(Pair("powhash", block.GetPOWHash().GetHex()));
+    result.push_back(Pair("powhash", block.GetPoWHash().GetHex()));
     CMerkleTx txGen(block.vtx[0]);
     txGen.SetMerkleBranch(&block);
     result.push_back(Pair("confirmations", (int)txGen.GetDepthInMainChain()));


### PR DESCRIPTION
Pretty trivial update but good for anyone interested in viewing the Proof-of-Work through the RPC. Since this doesn't affect storing the blockdata it shouldn't affect performance too much either.